### PR TITLE
fix unreachable broadcasting-service in default setup

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -95,7 +95,6 @@ read  -p 'Use TLS? (y/N): ' -r -n 1 -e TLS
 if [[ $TLS =~ ^[yY]$ ]]
 then
   echo "The certificates need to be placed in config/certs and their name configured in config/cert_config.yml."
-  sed -i 's/http:/https:/' .env
   sed -i 's/ws:/wss:/' .env
 fi
 


### PR DESCRIPTION
by don't let install.sh replace http with https in env file, even in TLS-mode.

BROADCAST_SERVICE_URI_PUSH is only used internally in the docker network. Therefore is does not only contain an internal address (http://testcenter-broadcasting-service) but must also use http since SSL is not used internally but only for the outside connection.